### PR TITLE
fix: local_test.pyのモジュールインポートパスを修正

### DIFF
--- a/local_test.py
+++ b/local_test.py
@@ -7,11 +7,11 @@ import os
 import sys
 from datetime import datetime
 
-# カレントディレクトリをモジュール検索パスに追加
-sys.path.append('.')
+# lambda_functionディレクトリをモジュール検索パスに追加
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lambda_function'))
 
 # モジュールをインポート
-from lambda_function.main import lambda_handler
+from main import lambda_handler
 
 def setup_env_vars():
     """環境変数を.envrcやシェルから取得して設定（未設定時のみデフォルト値）"""


### PR DESCRIPTION
## 概要

`local_test.py`の実行時にモジュールインポートエラーが発生していた問題を修正しました。

## 問題

Lambda関数内のコードが相対インポートから絶対インポートに変更されたため、`local_test.py`からの実行時に以下のエラーが発生していました：

```
ModuleNotFoundError: No module named 'discord_client'
```

## 修正内容

- `lambda_function`ディレクトリを正しくPythonパスに追加
- インポート文を`from lambda_function.main import lambda_handler`から`from main import lambda_handler`に変更

## テスト結果

修正後、`python local_test.py`が正常に実行され、Discordへの通知も成功しました。

🤖 Generated with [Claude Code](https://claude.ai/code)